### PR TITLE
✅ 현재 구현 완료

### DIFF
--- a/back/weverse/build.gradle
+++ b/back/weverse/build.gradle
@@ -32,6 +32,16 @@ dependencies {
    annotationProcessor 'org.projectlombok:lombok'
    testImplementation 'org.springframework.boot:spring-boot-starter-test'
    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+   
+   /*Spring Security*/
+   implementation 'org.springframework.boot:spring-boot-starter-security'
+   /*thymeleaf-extras-springsecurity6 패키지는 타임리프 템플릿 엔진과 스프링 시큐리티 프레임워크를 함께 사용할 때 필요한 타임리프의 확장 기능*/
+   implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+   
+   // JWT (JJWT)
+   implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+   runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+   runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/back/weverse/src/main/java/com/weverse/sb/config/JwtUtil.java
+++ b/back/weverse/src/main/java/com/weverse/sb/config/JwtUtil.java
@@ -1,0 +1,79 @@
+package com.weverse.sb.config;
+
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class JwtUtil {
+
+    private final String secretKey;
+    private final long expirationTime;
+    private final Key key;
+
+    // 생성자 주입으로 secretKey 받아와서 Key 객체 만듦
+    public JwtUtil(@Value("${jwt.secret}") String secretKey) {
+        this.secretKey = secretKey;
+        this.expirationTime = 1000 * 60 * 60 * 24; // 1일 (필요하면 @Value로 분리 가능)
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    // JWT 토큰 생성
+    public String generateToken(String email, String role) {
+        return Jwts.builder()
+                .setSubject(email) // 이메일을 subject에 저장
+                .claim("role", role)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expirationTime))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 이메일 추출
+    public String getEmailFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+
+    // 권한 추출
+    public String getRoleFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.get("role", String.class);
+    }
+
+    // 토큰 유효성 검사
+    public boolean isTokenValid(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+    
+    // 요청 헤더에서 Authorization 값 접두어 "Bearer " 제거
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7); // "Bearer " 제거
+        }
+        return null; // 토큰 없음
+    }
+}

--- a/back/weverse/src/main/java/com/weverse/sb/config/SecurityConfig.java
+++ b/back/weverse/src/main/java/com/weverse/sb/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.weverse.sb.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+	
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (초기 개발용)
+            .authorizeHttpRequests(auth -> auth
+            	.requestMatchers("/api/user/**").hasRole("USER")
+                .anyRequest().permitAll() // 전체 예외 처리
+            );
+        return http.build();
+    }
+	
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/back/weverse/src/main/java/com/weverse/sb/user/controller/AuthController.java
+++ b/back/weverse/src/main/java/com/weverse/sb/user/controller/AuthController.java
@@ -1,0 +1,59 @@
+package com.weverse.sb.user.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.weverse.sb.config.JwtUtil;
+import com.weverse.sb.user.dto.JwtResponseDto;
+import com.weverse.sb.user.dto.LoginRequestDto;
+import com.weverse.sb.user.dto.SignupRequestDto;
+import com.weverse.sb.user.entity.User;
+import com.weverse.sb.user.service.AuthService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+	
+	private final JwtUtil jwtUtil;
+    private final AuthService authService;
+    
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequestDto loginRequest) {
+        try {
+            User user = authService.login(loginRequest.getEmail(), loginRequest.getPassword());
+
+            String token = jwtUtil.generateToken(user.getEmail(), user.getRole());
+
+            // 토큰을 반환
+            return ResponseEntity.ok(new JwtResponseDto(token));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+    
+
+    @PostMapping("/check-email")
+    public ResponseEntity<Map<String, Object>> checkEmail(@RequestBody Map<String, String> req) {
+        String email = req.get("email");
+        boolean exists = authService.checkEmailExists(email);
+        Map<String, Object> result = new HashMap<>();
+        result.put("exists", exists);
+        return ResponseEntity.ok(result);
+    }
+    
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@RequestBody SignupRequestDto signupRequest) {
+        authService.signup(signupRequest);
+        return ResponseEntity.ok("회원가입 성공");
+    }
+}

--- a/back/weverse/src/main/java/com/weverse/sb/user/controller/JwtUserController.java
+++ b/back/weverse/src/main/java/com/weverse/sb/user/controller/JwtUserController.java
@@ -1,0 +1,56 @@
+package com.weverse.sb.user.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.weverse.sb.config.JwtUtil;
+import com.weverse.sb.user.dto.UpdateProfileRequestDto;
+import com.weverse.sb.user.dto.UserSettingsDto;
+import com.weverse.sb.user.service.JwtUserService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class JwtUserController {
+    private final JwtUserService jwtUserService;
+    private final JwtUtil    jwtUtil;
+
+    /**
+     * 내 정보 조회
+     */
+    @GetMapping("/me")
+    public ResponseEntity<UserSettingsDto> getMySettings(HttpServletRequest request) {
+        String token = jwtUtil.resolveToken(request);
+        if (token == null || !jwtUtil.isTokenValid(token)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        String email = jwtUtil.getEmailFromToken(token);
+        UserSettingsDto dto = jwtUserService.getUserSettingsByEmail(email);
+        return ResponseEntity.ok(dto);
+    }
+    
+    // 내 정보 수정
+    @PutMapping("/me")
+    public ResponseEntity<UserSettingsDto> updateMySettings(
+            HttpServletRequest request,
+            @RequestBody UpdateProfileRequestDto updateDto) {
+
+        String token = jwtUtil.resolveToken(request);
+        if (token == null || !jwtUtil.isTokenValid(token)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String email = jwtUtil.getEmailFromToken(token);
+        UserSettingsDto updated = jwtUserService.updateUserSettingsByEmail(email, updateDto);
+        return ResponseEntity.ok(updated);
+    }
+    
+} // class

--- a/back/weverse/src/main/java/com/weverse/sb/user/dto/JwtResponseDto.java
+++ b/back/weverse/src/main/java/com/weverse/sb/user/dto/JwtResponseDto.java
@@ -1,0 +1,10 @@
+package com.weverse.sb.user.dto;
+
+public class JwtResponseDto {
+	
+	private String token;
+    public JwtResponseDto(String token) { this.token = token; }
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+
+}

--- a/back/weverse/src/main/java/com/weverse/sb/user/dto/LoginRequestDto.java
+++ b/back/weverse/src/main/java/com/weverse/sb/user/dto/LoginRequestDto.java
@@ -1,0 +1,17 @@
+package com.weverse.sb.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequestDto {
+	
+    private String email;
+    private String password;
+    
+}

--- a/back/weverse/src/main/java/com/weverse/sb/user/dto/SignupRequestDto.java
+++ b/back/weverse/src/main/java/com/weverse/sb/user/dto/SignupRequestDto.java
@@ -1,0 +1,17 @@
+package com.weverse.sb.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequestDto {
+	
+	private String email;
+    private String password;
+
+}

--- a/back/weverse/src/main/java/com/weverse/sb/user/dto/UpdateProfileRequestDto.java
+++ b/back/weverse/src/main/java/com/weverse/sb/user/dto/UpdateProfileRequestDto.java
@@ -1,0 +1,16 @@
+package com.weverse.sb.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProfileRequestDto {
+    private String nickname;   // 닉네임 변경
+    private String name;       // 이름 변경
+    private String password;   // 새 비밀번호
+}

--- a/back/weverse/src/main/java/com/weverse/sb/user/dto/UserSettingsDto.java
+++ b/back/weverse/src/main/java/com/weverse/sb/user/dto/UserSettingsDto.java
@@ -1,0 +1,27 @@
+package com.weverse.sb.user.dto;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSettingsDto {
+	
+	private Long    userId;
+    private String  email;
+    private String  nickname;
+    private String  name;
+    private boolean passwordSet;            // 비밀번호 설정 여부
+    private String country;                 // 국가
+    private boolean smsVerified;            // SMS 인증(휴대폰 인증) 여부
+    
+    private LocalDate signupDate;           // 가입일
+
+
+}

--- a/back/weverse/src/main/java/com/weverse/sb/user/entity/User.java
+++ b/back/weverse/src/main/java/com/weverse/sb/user/entity/User.java
@@ -31,6 +31,9 @@ public class User {
 
     @Column(name = "password", length = 255, nullable = false)
     private String password;
+    
+    @Column(name = "role")
+    private String role;
 
     @Column(name = "name", length = 100, nullable = false)
     private String name;

--- a/back/weverse/src/main/java/com/weverse/sb/user/repository/UserRepository.java
+++ b/back/weverse/src/main/java/com/weverse/sb/user/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package com.weverse.sb.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +9,9 @@ import com.weverse.sb.user.entity.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>{
+	
+	boolean existsByEmail(String email);
+	
+	Optional<User> findByEmail(String email);
 
 }

--- a/back/weverse/src/main/java/com/weverse/sb/user/service/AuthService.java
+++ b/back/weverse/src/main/java/com/weverse/sb/user/service/AuthService.java
@@ -1,0 +1,73 @@
+package com.weverse.sb.user.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.weverse.sb.user.dto.SignupRequestDto;
+import com.weverse.sb.user.entity.User;
+import com.weverse.sb.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+	
+    private final UserRepository userRepository;
+    
+    private final PasswordEncoder passwordEncoder;
+    
+    // 이메일 체크
+    public boolean checkEmailExists(String email) {
+        return userRepository.existsByEmail(email);
+    }
+    
+    // 회원가입
+    @Transactional
+    public void signup(SignupRequestDto request) {
+        // 이메일 중복 체크
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
+        // 닉네임 자동생성 (ex. "user1234")
+        String nickname = "user" + System.currentTimeMillis();
+
+        // 패스워드 암호화
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        User user = User.builder()
+                .email(request.getEmail())
+                .password(encodedPassword)
+                .nickname(nickname)
+                .role("USER")
+                .name("회원")                     // ✅ 더미 값
+                .phoneNumber("010-0000-0000")     // ✅ 더미 값
+                .country("KR")                    // ✅ 더미 값
+                .jellyBalance(0)                  // ✅ NOT NULL
+                .cashBalance(0)                   // ✅ NOT NULL
+                .isEmailVerified(false)           // ✅ NOT NULL
+                .isSmsVerified(false)             // ✅ NOT NULL
+                .createdAt(LocalDateTime.now())   // ✅ NOT NULL
+                .build();
+
+        userRepository.save(user);
+    }
+    
+    // 로그인
+    public User login(String email, String password) {
+        // 1. 이메일로 사용자 조회
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+
+        // 평문 vs 암호화된 비번 비교!
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+        return user;
+    }
+    
+}

--- a/back/weverse/src/main/java/com/weverse/sb/user/service/JwtUserService.java
+++ b/back/weverse/src/main/java/com/weverse/sb/user/service/JwtUserService.java
@@ -1,0 +1,67 @@
+package com.weverse.sb.user.service;
+
+
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.weverse.sb.user.dto.UpdateProfileRequestDto;
+import com.weverse.sb.user.dto.UserSettingsDto;
+import com.weverse.sb.user.entity.User;
+import com.weverse.sb.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class JwtUserService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+   
+    //  현재 로그인한 사용자의 설정 정보 조회
+    public UserSettingsDto getUserSettingsByEmail(String email) {
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다. email=" + email));
+
+        return new UserSettingsDto(
+            user.getUserId(),
+            user.getEmail(),
+            user.getNickname(),
+            user.getName(),
+            user.getPassword() != null,       // 비밀번호 설정 여부
+            user.getCountry(),
+            user.getIsSmsVerified(),
+            user.getCreatedAt().toLocalDate() // 가입일
+        );
+    }
+    
+    // 내 정보 변경
+    @Transactional
+    public UserSettingsDto updateUserSettingsByEmail(String email, UpdateProfileRequestDto dto) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다. email=" + email));
+
+        // 변경 가능한 필드만 업데이트
+        if (dto.getNickname() != null) user.setNickname(dto.getNickname());
+        if (dto.getName() != null) user.setName(dto.getName());
+        if (dto.getPassword() != null && !dto.getPassword().isBlank()) {
+            user.setPassword(passwordEncoder.encode(dto.getPassword()));
+        }
+
+        userRepository.save(user);
+
+        return new UserSettingsDto(
+            user.getUserId(),
+            user.getEmail(),
+            user.getNickname(),
+            user.getName(),
+            user.getPassword() != null,
+            user.getCountry(),
+            user.getIsSmsVerified(),
+            user.getCreatedAt().toLocalDate()
+        );
+    }
+    
+} // class

--- a/back/weverse/src/main/resources/application.properties
+++ b/back/weverse/src/main/resources/application.properties
@@ -2,15 +2,18 @@ spring.application.name=weverse
 
 server.port=80
 
-# DB설정
+# DBì¤ì 
 spring.datasource.url=jdbc:mysql://localhost:3306/weverse_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=weverse
 spring.datasource.password=tiger
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-# JPA 설정
+# JPA ì¤ì 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+
+# jwt 키 값
+jwt.secret=q1W2e3R4t5Y6u7I8o9P0aS1dF2gH3jK4

--- a/back/weverse/src/test/java/com/weverse/sb/userTest/AuthControllerTest.java
+++ b/back/weverse/src/test/java/com/weverse/sb/userTest/AuthControllerTest.java
@@ -1,0 +1,122 @@
+package com.weverse.sb.userTest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weverse.sb.user.dto.LoginRequestDto;
+import com.weverse.sb.user.entity.User;
+import com.weverse.sb.user.repository.UserRepository;
+
+
+// @WebMvcTest(AuthController.class)
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)  // ⭐️ 시큐리티 필터 비활성화
+@Transactional
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    /*
+    @MockBean
+    private AuthService authService;
+    */
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    /*
+    @Test
+    void checkEmailExists_true() throws Exception {
+        String email = "test@example.com";
+        Mockito.when(authService.checkEmailExists(email)).thenReturn(true);
+
+        mockMvc.perform(post("/api/auth/check-email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\": \"" + email + "\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.exists").value(true));
+    }
+
+    @Test
+    void checkEmailExists_false() throws Exception {
+        String email = "noone@none.com";
+        Mockito.when(authService.checkEmailExists(email)).thenReturn(false);
+
+        mockMvc.perform(post("/api/auth/check-email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\": \"" + email + "\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.exists").value(false));
+    }
+    */
+       // 로그인 전용 테스트용 계정 저장
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+            .email("test@test.com")
+            .password(passwordEncoder.encode("test1234"))
+            .nickname("testUser")
+            .role("USER")
+            // ✅ 추가: NOT NULL 필드 기본값 세팅
+            .name("Test User")
+            .phoneNumber("010-0000-0000")
+            .country("KR")
+            .jellyBalance(0)
+            .cashBalance(0)
+            .isEmailVerified(false)
+            .isSmsVerified(false)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        userRepository.save(user);
+    }
+	
+    @Test
+    void 로그인_성공시_JWT_토큰_반환() throws Exception {
+        // GIVEN (이미 회원가입되어 있다고 가정)
+        String email = "test@test.com";
+        String password = "test1234";
+
+        String loginJson = String.format("{\"email\":\"%s\",\"password\":\"%s\"}", email, password);
+
+        // WHEN & THEN
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").exists());
+    }
+
+    @Test
+    void 로그인_실패_이메일_없음() throws Exception {
+        LoginRequestDto loginRequest = new LoginRequestDto("none@none.com", "test1234");
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(loginRequest)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 로그인_실패_비밀번호_틀림() throws Exception {
+        LoginRequestDto loginRequest = new LoginRequestDto("test@test.com", "wrongpw");
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(loginRequest)))
+            .andExpect(status().isBadRequest());
+    }
+
+}

--- a/back/weverse/src/test/java/com/weverse/sb/userTest/AuthServiceTest.java
+++ b/back/weverse/src/test/java/com/weverse/sb/userTest/AuthServiceTest.java
@@ -1,0 +1,108 @@
+package com.weverse.sb.userTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.weverse.sb.user.dto.SignupRequestDto;
+import com.weverse.sb.user.entity.User;
+import com.weverse.sb.user.repository.UserRepository;
+import com.weverse.sb.user.service.AuthService;
+
+
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc(addFilters = false)  // ⭐️ 시큐리티 필터 비활성화
+class AuthServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AuthService authService;
+
+    @Test
+    void checkEmailExists_withExistingEmail_returnsTrue() {
+        // given
+        User user = User.builder()
+        		.email("exist@a.com")
+        		.password("dummy1234")         // NOT NULL
+                .name("Dummy User")            // NOT NULL
+                .nickname("dummyNick")         // NOT NULL
+                .phoneNumber("010-0000-0000")  // NOT NULL
+                .country("KR")                 // NOT NULL
+                .jellyBalance(0)               // NOT NULL
+                .cashBalance(0)                // NOT NULL
+                .isEmailVerified(false)        // NOT NULL
+                .isSmsVerified(false)          // NOT NULL
+                .createdAt(LocalDateTime.now())// NOT NULL
+        		.build();
+        userRepository.save(user);
+
+        // when
+        boolean exists = authService.checkEmailExists("exist@a.com");
+
+        // then
+        assertTrue(exists);
+    }
+
+    @Test
+    void checkEmailExists_withNotExistingEmail_returnsFalse() {
+        boolean exists = authService.checkEmailExists("nobody@a.com");
+        assertFalse(exists);
+    }
+    
+    @Test
+    void 회원가입_정상_동작() {
+        // given
+        SignupRequestDto request = new SignupRequestDto("test@email.com", "test1234!");
+
+        // when
+        authService.signup(request);
+
+        // then
+        User user = userRepository.findByEmail("test@email.com").orElseThrow();
+        assertEquals("test@email.com", user.getEmail());
+        assertTrue(user.getPassword().startsWith("$2a$")); // bcrypt로 암호화 되었는지
+        assertNotNull(user.getNickname());
+    }
+
+    @Test
+    void 중복_이메일_회원가입_실패() {
+        // given
+        String email = "duplicate@email.com";
+        userRepository.save(User.builder()
+                .email(email)
+                .password("encoded_pw")
+                .nickname("user1234")
+                .name("회원")                    // ✅ 추가
+                .phoneNumber("010-0000-0000")   // ✅ 추가
+                .country("KR")                  // ✅ 추가
+                .jellyBalance(0)
+                .cashBalance(0)
+                .isEmailVerified(false)
+                .isSmsVerified(false)
+                .createdAt(LocalDateTime.now()) // ✅ 추가
+                .build());
+
+        SignupRequestDto request = new SignupRequestDto(email, "test1234!");
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> {
+            authService.signup(request);
+        });
+    }
+
+    
+}

--- a/back/weverse/src/test/java/com/weverse/sb/userTest/UserControllerTest.java
+++ b/back/weverse/src/test/java/com/weverse/sb/userTest/UserControllerTest.java
@@ -1,0 +1,70 @@
+package com.weverse.sb.userTest;
+
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.weverse.sb.config.JwtUtil;
+import com.weverse.sb.user.dto.UserSettingsDto;
+import com.weverse.sb.user.service.JwtUserService;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false) // 시큐리티 필터 비활성화
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtUserService jwtUserService;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    void 내정보_조회_API_성공_이메일기반() throws Exception {
+        // GIVEN
+        String email = "test@test.com";
+        UserSettingsDto dto = new UserSettingsDto(
+                1L,
+                email,
+                "tester",
+                "테스터",
+                true,
+                "대한민국",
+                true,
+                LocalDate.of(2025, 7, 30)
+        );
+
+        // JWT 동작 Mock
+        when(jwtUtil.resolveToken(org.mockito.ArgumentMatchers.any())).thenReturn("fakeToken");
+        when(jwtUtil.isTokenValid("fakeToken")).thenReturn(true);
+        when(jwtUtil.getEmailFromToken("fakeToken")).thenReturn(email);
+
+        // 서비스 Mock
+        when(jwtUserService.getUserSettingsByEmail(anyString())).thenReturn(dto);
+
+        // WHEN & THEN
+        mockMvc.perform(get("/api/user/me")
+                        .header("Authorization", "Bearer fakeToken")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1L))
+                .andExpect(jsonPath("$.email").value(email))
+                .andExpect(jsonPath("$.nickname").value("tester"))
+                .andExpect(jsonPath("$.smsVerified").value(true));
+    }
+}

--- a/back/weverse/src/test/java/com/weverse/sb/userTest/UserControllerUpdateTest.java
+++ b/back/weverse/src/test/java/com/weverse/sb/userTest/UserControllerUpdateTest.java
@@ -1,0 +1,79 @@
+package com.weverse.sb.userTest;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.weverse.sb.config.JwtUtil;
+import com.weverse.sb.user.dto.UserSettingsDto;
+import com.weverse.sb.user.service.JwtUserService;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerUpdateTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtUserService jwtUserService;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    void 내정보_수정_API_성공_닉네임_이름_비밀번호() throws Exception {
+        // GIVEN
+        String email = "test@test.com";
+
+        UserSettingsDto updatedDto = new UserSettingsDto(
+                1L,
+                email,
+                "newNickname",          // 변경된 닉네임
+                "새이름",                 // 변경된 이름
+                true,
+                "대한민국",
+                true,
+                LocalDate.of(2025, 7, 30)
+        );
+
+        // JWT Mock
+        when(jwtUtil.resolveToken(any())).thenReturn("fakeToken");
+        when(jwtUtil.isTokenValid("fakeToken")).thenReturn(true);
+        when(jwtUtil.getEmailFromToken("fakeToken")).thenReturn(email);
+
+        // Service Mock
+        when(jwtUserService.updateUserSettingsByEmail(any(), any())).thenReturn(updatedDto);
+
+        String json = """
+        {
+          "nickname": "newNickname",
+          "name": "새이름",
+          "password": "newPassword1234"
+        }
+        """;
+
+        // WHEN & THEN
+        mockMvc.perform(put("/api/user/me")
+                        .header("Authorization", "Bearer fakeToken")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nickname").value("newNickname"))
+                .andExpect(jsonPath("$.name").value("새이름"));
+    }
+}
+

--- a/back/weverse/src/test/java/com/weverse/sb/userTest/UserServiceTest.java
+++ b/back/weverse/src/test/java/com/weverse/sb/userTest/UserServiceTest.java
@@ -1,0 +1,58 @@
+package com.weverse.sb.userTest;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.weverse.sb.user.dto.UserSettingsDto;
+import com.weverse.sb.user.entity.User;
+import com.weverse.sb.user.repository.UserRepository;
+import com.weverse.sb.user.service.JwtUserService;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private JwtUserService jwtUserService;
+
+    @Test
+    void 이메일_기반_유저_설정_조회_성공() {
+        // GIVEN
+        String email = "test@test.com";
+        User user = User.builder()
+                .userId(1L)
+                .email(email)
+                .nickname("tester")
+                .name("테스터")
+                .password("encodedPwd")
+                .country("대한민국")
+                .isSmsVerified(true)
+                .createdAt(LocalDateTime.of(2025, 7, 30, 10, 0))
+                .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        // WHEN
+        UserSettingsDto dto = jwtUserService.getUserSettingsByEmail(email);
+
+        // THEN
+        assertThat(dto.getUserId()).isEqualTo(1L);
+        assertThat(dto.getEmail()).isEqualTo(email);
+        assertThat(dto.getNickname()).isEqualTo("tester");
+        assertThat(dto.isSmsVerified()).isTrue();
+        assertThat(dto.getSignupDate()).isEqualTo(java.time.LocalDate.of(2025, 7, 30));
+    }
+}
+

--- a/back/weverse/src/test/java/com/weverse/sb/userTest/WeverseApplicationTests.java
+++ b/back/weverse/src/test/java/com/weverse/sb/userTest/WeverseApplicationTests.java
@@ -1,0 +1,13 @@
+package com.weverse.sb.userTest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class WeverseApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
회원가입 / 로그인 / JWT 발급 및 인증 (JwtUtil)
마이페이지 조회(GET/api/user/me)
마이페이지수정(PUT/api/user/me) – 닉네임, 이름, 비밀번호

user 엔티티에 Role 컬럼 추가
권한 확인용으로 SecurityConfig에 .requestMatchers("/api/user/**").hasRole("USER") 추가 
지금 필요 없다면 주석처리해주세요